### PR TITLE
Swap statistics using sysctl

### DIFF
--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -11,6 +11,12 @@
   This "Meter" written by Ian P. Hands (iphands@gmail.com, ihands@redhat.com).
 */
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFDateFormatter.h>
+#include <CoreFoundation/CFString.h>
+#include <IOKit/ps/IOPowerSources.h>
+#include <IOKit/ps/IOPSKeys.h>
+
 #include "Meter.h"
 #include "ProcessList.h"
 #include "CRT.h"

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ applications_DATA = htop.desktop
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = htop.png
 
-htop_CFLAGS = -pedantic -Wall -std=c99 -D_XOPEN_SOURCE_EXTENDED
+htop_CFLAGS = -pedantic -Wall -std=c99 -D_XOPEN_SOURCE_EXTENDED -framework IOKit -framework CoreFoundation
 AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\"
 
 

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -750,10 +750,10 @@ ProcessList_getSwap( ProcessList * this ) {
   int mib[2] = { CTL_VM, VM_SWAPUSAGE };
 
   if ( sysctl( mib, 2, NULL, &bufSize, NULL, 0 ) < 0 )
-    printf( "Failure calling sysctl" );
+    die( "Failure calling sysctl" );
 
   if ( sysctl( mib, 2, &swap, &bufSize, NULL, 0 ) < 0 )
-    printf( "Failure calling sysctl" );
+    die( "Failure calling sysctl" );
 
   this->totalSwap = swap.xsu_total / 1024;
   this->freeSwap = swap.xsu_avail / 1024;


### PR DESCRIPTION
I have implemented swap statistics, using the same numbers as reported by `sysctl vm.swapusage` on the command line.

Maybe this should really be in `SwapMeter.c` instead of `ProcessList.c`?
